### PR TITLE
feat: Add shot notes and full curve data to get_shot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "@types/ws": "^8.5.10",
         "tsx": "^4.7.0",
         "typescript": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {


### PR DESCRIPTION
- Add fetchShotNotesFromGaggimate() to fetch notes via WebSocket API
- Include notes (grindSetting, beanType, doseIn/Out, ratio, taste) in get_shot response
- Add includeFullCurve parameter to get_shot for complete extraction curve data
- Modify transformer to optionally return all ~100 sample points